### PR TITLE
fix preview image does not fit preview-container

### DIFF
--- a/src/js/core/PreviewContainer.js
+++ b/src/js/core/PreviewContainer.js
@@ -48,7 +48,7 @@ export default class PreviewContainer extends DomClass {
         super(player, {attributes, parent: parentElement});
 
         this._img = createElementWithHtmlText(`
-        <div>
+        <div style="${g_imgStyle}">
             <img style="${g_imgStyle}" src="${backgroundImage}" alt=""/>
             <div style="${ g_iconContainerStyle }">
                 <i class="preview-play-icon" style="${ g_iconStyle }">${ PlayIcon }</i>


### PR DESCRIPTION
The preview image nested in an additional div prevents it from fitting into the preview container.

![grafik](https://user-images.githubusercontent.com/35195803/171483663-d36527df-e281-440f-9a3a-3858d8c521b9.png)
