### PR TITLE
Fix url cache variable

### DIFF
--- a/src/js/videoFormats/es.upv.paella.hlsVideoFormat.js
+++ b/src/js/videoFormats/es.upv.paella.hlsVideoFormat.js
@@ -146,7 +146,7 @@ const loadHls = (player, streamData, video, config, cors) => {
         });
 
         const rand = Math.floor(Math.random() * 100000000000);
-        const url = hlsStream.src + (/\?/.test(url) ? `&cache=${rand}` : `?cache=${rand}`);
+        const url = hlsStream.src + (/\?/.test(hlsStream.src) ? `&cache=${rand}` : `?cache=${rand}`);
         hls.loadSource(url);
         hls.attachMedia(video);
 


### PR DESCRIPTION
This fixes paella cache variable. Now will detect if the URL have an `?` and it will set the correct character for the URL