### PR TITLE
Fixed a bug in the main audio player selection

### DIFF
--- a/src/js/core/StreamProvider.js
+++ b/src/js/core/StreamProvider.js
@@ -60,6 +60,14 @@ export default class SteramProvider extends PlayerResource {
 			}
 		})
 		
+		if (!(mainAudioContent in this._streams)) {
+			const streams = Object.values(this._streams);
+			if (streams.length) {
+				streams[0].isMainAudio = true;
+				mainAudioContent = streams[0].stream.content;
+			}
+		}
+
 		let videoEndedEventTimer = null;
 		for (const content in this._streams) {
 			const s = this._streams[content];


### PR DESCRIPTION
When no stream is marked `mainAudio`, and there is no stream with
the default main audio flavor, Paella behaves as described in #97
because it lacks a "main audio player."

This patch adds a fallback for this situation; it just picks
the first stream as the main audio source.

Closes #97.