### PR TITLE
Add Simple CI Test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Test Paella
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set-up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
+
+    - name: Install Dependencies
+      run: npm ci
+
+    - name: Build Paella
+      run: npm run build


### PR DESCRIPTION
This patch adds a very simple CI test for pull requests to ensure that patches do not break the build. This does not yet test much, but we can always extend this later.