### PR TITLE
Implement Fallback Identifier

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,9 +1,11 @@
 {
+    "fallbackId": "belmar-multiresolution-remote",
+
     "repositoryUrl": "repository",
     "manifestFileName": "data.json",
 
     "defaultLayout": "presenter-presentation",
-    
+
     "defaultAudioStream": "presenter",
 
     "defaultVideoPreview": "/config/default_preview.jpg",
@@ -50,7 +52,7 @@
             "required": false
         }
     ],
-    
+
     "plugins": {
         "es.upv.paella.testPlugin": {
             "enabled": true,
@@ -152,7 +154,7 @@
         "es.upv.paella.audioVideoFormat": {
             "enabled": true
         },
-        
+
         "es.upv.paella.playPauseButton": {
             "enabled": true,
             "order": 1,

--- a/doc/initialization.md
+++ b/doc/initialization.md
@@ -86,9 +86,16 @@ import { utils } from 'paella-core';
 const { getUrlParameter } = utils;
 
 
-export async function defaultGetVideoIdFunction(config,player) {
+/**
+ * Get video identifier from URL or configuration.
+ * The identifier is selected from the first provider in the following order:
+ * - URL hash parameter: #id=xy
+ * - URL search parameter: ?id=xy
+ * - Configuration option `fallbackId`
+ */
+export async function defaultGetVideoIdFunction(config, player) {
     player.log.debug("Using default getVideoId function");
-    return getUrlParameter("id");
+    return getHashParameter("id") || getUrlParameter("id") || config.fallbackId;
 }
 ```
 

--- a/src/js/core/initFunctions.js
+++ b/src/js/core/initFunctions.js
@@ -6,9 +6,9 @@ export async function defaultLoadConfigFunction(configUrl,player) {
     return response.json();
 }
 
-export async function defaultGetVideoIdFunction(config,player) {
+export async function defaultGetVideoIdFunction(config, player) {
     player.log.debug("Using default getVideoId function");
-    return getHashParameter("id") || getUrlParameter("id");
+    return getHashParameter("id") || getUrlParameter("id") || config.fallbackId;
 }
 
 export async function defaultGetManifestUrlFunction(repoUrl,videoId,config,player) {


### PR DESCRIPTION
This patch allows users to specify a fallback identifier in the configuration. This identifier is used if no identifier is specified via URL parameter.

This functionality is mostly useful for testing, although it can also be useful for production, since you can now specify a valid fallback for deployments and users/testers do not have to remember a specific URL parameter or identifier.

For example, you can now run `npm run dev` and the URL printed in the command line will now actually work.