### PR TITLE
Fix Publish Workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,9 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
-# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
-
-name: Publish 1.1.x
+name: Publish
 
 on:
-  create:
+  push:
     tags:
-      - '1.1.*'
+      - '*'
 
 jobs:
   publish-npm:


### PR DESCRIPTION
The workflow “Publish 1.1.x” does probably not what it is intended to do. The workflow runs on the event [create](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#create) which runs the workflow when someone creates any Git reference. The additional `tags` setting has no effect at all.

That is why the workflow also runs on non-tagged commits pushed to the repository and, despite the `1.1.x` filter does also run on the current 1.8.x releases.

Assuming you want to run on all tags created in the `paella-core` repository, this patch changes the workflow to run on all tags, but only on tags.

It also removes the filter and naming related to `1.1.x` since I don't think that's relevant any longer.