### PR TITLE
Use SPDX Identifier for License

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "hls"
   ],
   "author": "Fernando Serrano Carpena <ferserc1@gmail.com>",
-  "license": "SEE LICENSE IN license.txt",
+  "license": "ECL-2.0",
   "bugs": {
     "url": "https://github.com/polimediaupv/paella-core/issues"
   },


### PR DESCRIPTION
The license field in the `package.json` should use a SPDX license identifier if possible, so that the package license can be easily identified:

- https://docs.npmjs.com/cli/v8/configuring-npm/package-json#license

This patch sets the license to `ECL-2.0`, which is the SPDX license identifier for the Educational Community License v2.0:

- https://spdx.org/licenses/ECL-2.0.html