### PR TITLE
Fix link to project page

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,4 @@ You can also debug the Paella Player core features with the included minimal pla
 % npm run dev
 ```
 
-You can get more information about Paella and its development in the [documentation](https://paellaplayer.upv.es/docs/).
-
+You can get more information about Paella and its development in the [documentation](https://paellaplayer.upv.es).


### PR DESCRIPTION
This linked documentation no longer exists.
This patch updates the link to the Paella project page.