### PR TITLE
Error if no identifier is provided

### DIFF
--- a/src/js/Paella.js
+++ b/src/js/Paella.js
@@ -386,6 +386,9 @@ export default class Paella {
             await loadKeyShortcutPlugins(this);
     
             this._videoId = await this.initParams.getVideoId(this._config, this);
+            if (this.videoId === null) {
+                throw new Error('No video identifier specified');
+            }
     
             this._manifestUrl = await this.initParams.getManifestUrl(this.repositoryUrl,this.videoId,this._config,this);
             


### PR DESCRIPTION
If no identifier is provided to the player, users will end up with the very cryptic message `part is null`. That is not very helpful.

This patch checks for the existence of an identifier, returning “No video identifier specified” instead.

![Screenshot from 2022-10-28 15-27-54](https://user-images.githubusercontent.com/1008395/198619135-c7d3baac-34b1-4f6c-afda-e2116f046113.png)
