### PR TITLE
Update Workflow Dependencies

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,11 +9,10 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 14
-          registry-url: https://registry.npmjs.org/
+          node-version: 16
       - run: npm ci
       - run: npm publish --access public
         env:


### PR DESCRIPTION
This patch updates a few workflow dependencies. Most notably, it switches to the current Node.js LTS version for building Paella.