### PR TITLE
Allow the ProgressIndicator to be enabled/disabled

### DIFF
--- a/src/js/core/ProgressIndicator.js
+++ b/src/js/core/ProgressIndicator.js
@@ -235,8 +235,6 @@ export default class ProgressIndicator extends DomClass {
 			}, 250);
 		}
 
-		this._enabled = player.config.progressIndicator?.enabled;
-
 		this._updateCanvas = true;
 		updateCanvasProcess();
 	}
@@ -268,30 +266,19 @@ export default class ProgressIndicator extends DomClass {
 		await unloadPluginsOfType(this.player, "progressIndicator");
 	}
 
-	get enabled() {
-		return this._enabled;
+	hideTimeLine(hideProgressTimer=true){
+		if(hideProgressTimer){
+			this.hideProgressTimer();
+		}
+		this.hideProgressContainer()
 	}
 
-	set enabled(e) {
-		this._enabled = e;
-		if (!this._enabled) {
-			this.hide();
-		}
-		else {
-			this.showUserInterface();
-		}
+	hideProgressContainer(){
+		this.progressContainer.style.display = "none";
 	}
 
-	hideUserInterface() {
-		this.player.log.debug("Hide playback bar user interface");
-		this.hide();
-	}
-
-	showUserInterface() {
-		if (this._enabled) {
-			this.show();
-			this.onResize();
-		}
+	hideProgressTimer(){
+		this.progressTimer.style.display = "none";
 	}
 
 	get playbackBar() {


### PR DESCRIPTION
The behaviour is the same as the one in the `PlaybackBar`, so basically the user is able to hide or show the progress bar just by changing the value of the `enabled` attribute once the player is `PLAYER_LOADED` state:

```js
player.bindEvent(player.Events.PLAYER_LOADED, () => {
    player.playbackBar.progressIndicator.enabled = false;
}, false);
```

If find this useful to live events when the user actions on the progress bar can affect negatively the stream playback.

I'm not sure if the white space between the `PlaybackBar` and the video container could be removed somehow, since it is a bit aesthetic.

Just let me know what you think.

Related issue #177