### PR TITLE
Export DFXP caption libs and return fetch promise in caption manifests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,7 @@ import Loader from './js/core/Loader';
 import { DomClass, createElementWithHtmlText, createElement } from 'paella-core/js/core/dom';
 
 import WebVTTParser, { parseWebVTT } from './js/captions/WebVTTParser';
+import DFXPParser, { parseDFXP } from './js/captions/DFXPParser';
 import CaptionsPlugin from 'paella-core/js/captions/CaptionsPlugin';
 import Captions from 'paella-core/js/captions/Captions';
 
@@ -87,6 +88,7 @@ import TripleVideoLayoutPlugin from './js/layouts/es.upv.paella.tripleVideo';
 
 // Captions
 import VttManifestCaptionsPlugin from './js/plugins/es.upv.paella.vttManifestCaptionsPlugin';
+import DfxpManifestCaptionsPlugin from './js/plugins/es.upv.paella.dfxpManifestCaptionsPlugin';
 
 
 // Video canvas
@@ -148,6 +150,8 @@ export {
 
     WebVTTParser,
     parseWebVTT,
+    DFXPParser,
+    parseDFXP,
     CaptionsPlugin,
     Captions,
 
@@ -187,6 +191,7 @@ export {
     PlayPauseButtonPlugin,
 
     VttManifestCaptionsPlugin,
+    DfxpManifestCaptionsPlugin,
 
     SingleVideoLayoutPlugin,
     DualVideoLayoutPlugin,

--- a/src/js/plugins/es.upv.paella.vttManifestCaptionsPlugin.js
+++ b/src/js/plugins/es.upv.paella.vttManifestCaptionsPlugin.js
@@ -19,7 +19,7 @@ export default class VttManifestCaptionsPlugin extends CaptionsPlugin {
             p.push(new Promise((resolve, reject) => {
                 if (/vtt/i.test(captions.format)) {
                     const fileUrl = resolveResourcePath(this.player, captions.url);
-                    fetch(fileUrl)
+                    return fetch(fileUrl)
                         .then(fetchResult => {
                             if (fetchResult.ok) {
                                 return fetchResult.text();
@@ -37,9 +37,12 @@ export default class VttManifestCaptionsPlugin extends CaptionsPlugin {
                         })
                     
                 }
+                else {
+                    reject();
+                }
             }));
         });
-        await Promise.all(p);
+        await Promise.allSettled(p);
         return result;
     }
 }


### PR DESCRIPTION
This pull does 3 things:
1. Exports the new DFXP caption libraries to paella-core index file lib exports (same way as VTT libs)
2. Patches the caption manifest loop by returning the fetch promise (for both DFXP and VTT)
3. Adds a DFXP caption file garbage character cleanup that was in Paella 6.5, which appears to be necessary for IBM Watson DFXP captions.