### PR TITLE
Check if fullscreenEnabled prior to requesting to go full screen

### DIFF
--- a/src/js/Paella.js
+++ b/src/js/Paella.js
@@ -907,8 +907,15 @@ export default class Paella {
     }
     
     isFullScreenSupported() {
-        return this.containerElement.requestFullscreen ||
-            this.containerElement.webkitRequestFullScreen;
+        const allowedToGoFullScreen = (
+            window.document.fullscreenEnabled ||
+            window.document.webkitFullscreenEnabled
+        );
+        const canRequestToGoFullScreen = (
+            this.containerElement.requestFullscreen ||
+            this.containerElement.webkitRequestFullScreen
+        );
+        return allowedToGoFullScreen && canRequestToGoFullScreen;
     }
     
     async enterFullscreen() {


### PR DESCRIPTION
This pull resolves the issue of attempting to go full screen when the window does not allow the player to go full screen. 

To Test this using the dummy HTML below
1. Change the "Change this for the the Paella Player LocalHost testing link HERE" with your local player link. Notice that before the code in this pull, the fullscreen button is shown and creates and error when pressed.
2. Using the code in this pull, the full screen icon is not visible because this iFrame does not allow it.
3. Add `allow="fullscreen"` to the iFrame element below. Now the the fullscreen button now is shown (with this pull code). When the fullscreen button is pressed, the player goes full screen and there is no error.

```
<!DOCTYPE html>
<html xmlns="http://www.w3.org/1999/xhtml">
  <head>
    <title>TEST of embedded Player that is not allowed to go full screen</title>
  </head>
  <body>
    <iframe src="Change this for the the Paella Player LocalHost testing link HERE" width="800" height="500"></iframe>
  </body>
</html>
```