### PR TITLE
Re-introduce ability to change quality for progressive download sources (e.g. mp4 files)

### DIFF
--- a/src/js/videoFormats/es.upv.paella.mp4VideoFormat.js
+++ b/src/js/videoFormats/es.upv.paella.mp4VideoFormat.js
@@ -191,6 +191,7 @@ export class Mp4Video extends Video {
         const currentTime = this.video.currentTime;
         const playbackRate = this.video.playbackRate;
         this.clearStreamData();
+        this.video.autoplay = true;
         this.video.src = q.src;
         this.video.currentTime = currentTime;
         this.video.playbackRate = playbackRate;
@@ -201,6 +202,8 @@ export class Mp4Video extends Video {
         await new Promise(resolve => {
             const f = () => {
                 this._ready = true;
+                this.video.autoplay = false;
+                this.video.pause();
                 this.video.removeEventListener('canplay', f);
                 resolve(null);
             };


### PR DESCRIPTION
Closes #342

I think I managed to get this highly requested feature working. This was tested in many different browsers and devices and everything seems to work as expected. You can [test this PR here](https://pr1100.tobira.opencast.org/) (try the videos from "Mixed Test Series").

Unfortunately, this cannot be achieved by just having a separate video format plugin: the `StreamProvider` has to coordinate pausing and resuming. That cannot be done by each video format individually. So I was forced to touch `paella-core` code anyway. See the commits for details on how this was solved.
I think this works robustly enough to be integrated into `paella-core` so that all users can just benefit from this patch.

The last commit in this PR changes the way the initial quality is selected. See the commit message for more information.

I am aware that the UX could be improved still by showing a spinner while the new quality is loading, but this PR focuses on the functionality. The spinner can easily be added later, if requested.
