### PR TITLE
Fix bug in `loadStyle` and add `destroy` method for cleanup

### DIFF
--- a/src/js/Paella.js
+++ b/src/js/Paella.js
@@ -284,10 +284,10 @@ export default class Paella {
         // Load status flags
         this._playerLoaded = false;
 
-        const resize = () => {
+        this._resizeEventListener = () => {
             this.resize();
         }
-        window.addEventListener("resize", resize);
+        window.addEventListener("resize", this._resizeEventListener);
         
         this.containerElement.addEventListener("fullscreenchange", () => {
             triggerEvent(this, Events.FULLSCREEN_CHANGED, { status: this.isFullscreen });
@@ -821,6 +821,37 @@ export default class Paella {
         
         unregisterEvents(this);
         this._playerState = PlayerState.MANIFEST;
+    }
+
+    /**
+     * Unloads and then completely removes this Paella instance. Reverts all
+     * effects of the constructor. This method is useful for SPAs where the
+     * instance should be completely removed on navigation, for example. The
+     * Paella instance cannot be used anymore after this method is called.
+     */
+    async destroy() {
+        await this.unload();
+
+        // Now undo every side effects that the constructor caused, in reverse order.
+        window.removeEventListener("resize", this._resizeEventListener);
+
+        setTranslateFunction(defaultTranslateFunction);
+        setSetLanguageFunction(defaultSetLanguageFunction);
+        setGetLanguageFunction(defaultGetLanguageFunction);
+        setAddDictionaryFunction(defaultAddDictionaryFunction);
+        setGetDictionariesFunction(defaultGetDictionariesFunction);
+        setGetDefaultLanguageFunction(defaultGetDefaultLanguageFunction);
+
+        // The constructor add `player-container` to the element's class list,
+        // but we don't know if it was present before. We just leave it as this
+        // is unlikely to cause problems.
+
+        if (window.__paella_instances__ && typeof(window.__paella_instances__) === "array") {
+            const index = window.__paella_instances__.indexOf(this);
+            if (index > -1) {
+                window.__paella_instances__.splice(index, 1);
+            }
+        }
     }
 
     async reload(onUnloadFn = null) {

--- a/src/js/core/utils.js
+++ b/src/js/core/utils.js
@@ -273,7 +273,7 @@ export function loadStyle(url, addToHeader = true) {
         if (addToHeader) {
             head.appendChild(link);
         }
-        resolve();
+        resolve(link);
     });
 }
 


### PR DESCRIPTION
Hi there! 

In Tobira we noticed that unloading a Paella instance and loading a new one caused some console errors and other weird behavior. This PR tries to address some of that. The first commit adds a `destroy` method which does a complete cleanup. This is very useful for SPAs like Tobira, where Paella instances are created and destroyed again, and that shouldn't leave any traces. Without this `destroy` method, certain event handlers and other global values still exist. The `destroy` method fixes that.

The second commit is a simple bug fix where a promise sometimes returned `undefined` (by calling `resolve()` without arguments). That `undefined` value is later passed to a function that throws an error. You can see that on tobira.opencast.org when clicking on one video and then on a second one.

I hope these changes are ok like this!