### PR TITLE
iOS set muted attribute on non-audio video

### DIFF
--- a/src/js/videoFormats/es.upv.paella.mp4VideoFormat.js
+++ b/src/js/videoFormats/es.upv.paella.mp4VideoFormat.js
@@ -39,6 +39,7 @@ export class Mp4Video extends Video {
 
         // The video is muted by default, to allow autoplay to work
         if (!isMainAudio) {
+            this.element.setAttribute("muted", "");
             this.element.muted = true;
         }
 


### PR DESCRIPTION
Patches iOS to set the muted attribute on the non-audio video when playing a multi-video on iOS device.