### PR TITLE
Fix bug where mp4 autoplay videos weren't paused until all streams loaded

### DIFF
--- a/src/js/videoFormats/es.upv.paella.mp4VideoFormat.js
+++ b/src/js/videoFormats/es.upv.paella.mp4VideoFormat.js
@@ -247,8 +247,8 @@ export class Mp4Video extends Video {
         catch (err) {
             // Prevent AbortError exception
         }
-        await this.waitForLoaded();
-        
+        await this.waitForLoaded(true);
+
         this.player.log.debug(`es.upv.paella.mp4VideoFormat (${ this.streamData.content }): video loaded and ready.`);
         this.saveDisabledProperties(this.video);
     }
@@ -279,9 +279,12 @@ export class Mp4Video extends Video {
         return this._videoEnabled;
     }
 
-    waitForLoaded() {
+    waitForLoaded(pauseOnLoaded) {
         return new Promise((resolve,reject) => {
             if (this.video.readyState>=2) {
+                if (pauseOnLoaded) {
+                    this.video.pause();
+                }
                 this._ready = true;
             }
 
@@ -291,7 +294,9 @@ export class Mp4Video extends Video {
             else {
                 this._handleLoadedCallback = evt => {
                     if (this.video.readyState>=2) {
-                        this.video.pause();
+                        if (pauseOnLoaded) {
+                            this.video.pause();
+                        }
                         this._ready = true;
                         resolve();
                     }


### PR DESCRIPTION
When starting a  dual stream video, it could regularly happen that the user already heard the audio from one stream, but the loading spinner was still shown. That's because MP4 streams are included with a `<video>` tag that has `autoplay`. This is unfortunately required for some browsers to properly load. Paella needs to immediately pause the video when it loaded. It is only supposed to start playing once all streams have loaded and a "play" command is coming from the StreamProvider.

This behavior got broken in bc37279f4: a new branch was added to waitForLoaded that could lead to `resolve()` being called, but there the `pause` was forgotten. I couldn't just add the `pause` as waitForLoaded is used in many places, and we don't always want to pause. So I added a boolean parameter to only do it when called from `loadStream`.

---

If you need a test deployment to test this bug and the fix, let me know.