### PR TITLE
Allow FireFox to play at readystate 2, but protect other browsers

### DIFF
--- a/src/js/videoFormats/es.upv.paella.hlsVideoFormat.js
+++ b/src/js/videoFormats/es.upv.paella.hlsVideoFormat.js
@@ -309,11 +309,15 @@ export class HlsVideo extends Mp4Video {
         else {
             await (new Promise((resolve,reject) => {
                 const checkReady = () => {
-                    // readyState === 2: HAVE_CURRENT_DATA. Data is available for the current playback
-                    // position, but not enought to actually play more than one frame. In firefox, the
-                    // video returns readyState === 2 when the video reaches the end, so the correct
-                    // comparision here is >= instead of >
-                    if (this.video.readyState >= 2) {
+                    // Make a special case to allow Firefox to play at readyState 2.
+                    // Browsers like Safari drop from readyState 3 to readyState 2 when the video is
+                    // buffering and cannot be played. Chrome moves quickly between ready state
+                    // 2 to 3 when it is able to play and is not impacted by this issue.
+                    if (/Firefox/.test(navigator.userAgent) && this.video.readyState == 2) {
+                        this._ready = true;
+                        resolve();
+                    }
+                    else if (this.video.readyState > 2) {
                         this._ready = true;
                         resolve();
                     }


### PR DESCRIPTION
This pull prevents a premature play() request on video elements at readystate 2, except for Firefox that is ready to play  at ready state 2.

Safari drops from readystate 3 to readystate 2 when it is buffering and cannot play a video. Requesting play() on Safari at readystate 2 causes the video to stall.

Chrome is not impacted by this pull because it moves quickly from readystate 2 to 3 during load. This also appears to be the case for other browsers.

Our site has been using this patch for many months with a diverse (in regards to devices and OS) and remote student body.