### PR TITLE
Enhance aria labeling of play-pause button

### DIFF
--- a/src/js/plugins/es.upv.paella.playPauseButton.js
+++ b/src/js/plugins/es.upv.paella.playPauseButton.js
@@ -8,9 +8,10 @@ import defaultReplayIcon from 'paella-core/icons/replay.svg';
 import PaellaCorePlugins from './PaellaCorePlugins';
 
 export default class PlayButtonPlugin extends ButtonPlugin {
+
 	getPluginModuleInstance() {
-        return PaellaCorePlugins.Get();
-    }
+		return PaellaCorePlugins.Get();
+	}
 	
 	get name() {
 		return super.name || "es.upv.paella.playPauseButton";
@@ -21,17 +22,32 @@ export default class PlayButtonPlugin extends ButtonPlugin {
 		const pauseIcon = this.player.getCustomPluginIcon(this.name,"pause") || defaultPauseIcon;
 		const replayIcon = this.player.getCustomPluginIcon(this.name,"replay") || defaultReplayIcon;
 		this.icon = playIcon;
+		const defaultTitlePause = "pause";
+		const defaultTitlePlay = "play";
+		const defaultShortcutKey = "k";
 		bindEvent(this.player, Events.PLAY, () => {
 			this.icon = pauseIcon;
+			this._button.ariaKeyshortcuts = this.config.ariaKeyshortcuts || defaultShortcutKey ;
+			this._button.ariaLabel = this.config.ariaLabelPause || defaultTitlePause;
+			this._button.title = this.config.ariaLabelPause || defaultTitlePause;
 		});
 		bindEvent(this.player, Events.PAUSE, () => {
 			this.icon = playIcon;
+			this._button.ariaKeyshortcuts = this.config.ariaKeyshortcuts || defaultShortcutKey ;
+			this._button.ariaLabel = this.config.ariaLabelPause || defaultTitlePlay ;
+			this._button.title = this.config.ariaLabelPause || defaultTitlePlay;
 		});
 		bindEvent(this.player, Events.ENDED, () => {
 			this.icon = replayIcon;
+			this._button.ariaKeyshortcuts = this.config.ariaKeyshortcuts || defaultShortcutKey ;
+			this._button.ariaLabel = this.config.ariaLabelPause || defaultTitlePlay ;
+			this._button.title = this.config.ariaLabelPause || defaultTitlePlay;
 		});
 		bindEvent(this.player, Events.STOP, () => {
 			this.icon = playIcon;
+			this._button.ariaKeyshortcuts = this.config.ariaKeyshortcuts || defaultShortcutKey ;
+			this._button.ariaLabel = this.config.ariaLabelPause || defaultTitlePlay ;
+			this._button.title = this.config.ariaLabelPause || defaultTitlePlay;
 		});
 	}
 	


### PR DESCRIPTION
This pull is a request to enhance the Player play-pause aria labelling to make it dynamic. Similar to the Youtube aria handling.

- This pull needs the addition of language nationalization handling.
- The "ariaKeyshortcuts" config is related to a companion request to make the shortcuts info plugin listing dynamic based on active plugins, instead of a generic list.

Example of config additions for this change,
```
        "es.upv.paella.playPauseButton" : {
            "enabled": true,
            "order": 0,
            "tabIndex": 1,
            "ariaKeyshortcuts": "k",
            "ariaLabelPlay": "Play",
            "ariaLabelPause": "Pause"

        },
```