### PR TITLE
Prevent jumpy timeline when doing multiple quick successive seeks with HLS video

### DIFF
--- a/src/js/videoFormats/es.upv.paella.hlsVideoFormat.js
+++ b/src/js/videoFormats/es.upv.paella.hlsVideoFormat.js
@@ -309,6 +309,9 @@ export class HlsVideo extends Mp4Video {
         else {
             await (new Promise((resolve,reject) => {
                 const checkReady = () => {
+		    if (this._ready) {
+                        resolve();
+                    }
                     // Make a special case to allow Firefox to play at readyState 2.
                     // Browsers like Safari drop from readyState 3 to readyState 2 when the video is
                     // buffering and cannot be played. Chrome moves quickly between ready state
@@ -492,3 +495,4 @@ export default class HlsVideoPlugin extends VideoPlugin {
         };
     }
 }
+


### PR DESCRIPTION
The jumpy timeline on rapid skip button clicks happens in Chrome browser.

TMI: Hi UPV, Last summer I overrode UPV's mp4 and HLS code to solve some issues with our site's HLS videos. One of them was an issue with a jumpy timeline and chaotic video seek behaviour when someone vigorously clicks the seek forward or seek backward several times sequentially on a **multi-video event**. Yes, this is a real student use case.

The new UPV code still has the issue. After a dissecting my old code, applying and testing parts, the 3 lines of code in this pull resolved the issue locally. I will continue testing because I don't get why this works. But, it can't hurt, so here it is.

To duplicate the issue:
- Go to: https://paellaplayer.upv.es/player.html?id=hls-multiquality
- Play the video, then click the seek forward button quickly multiple times.
- EXPECTED: the video seeking is smooth and the timeline/current time doesn't jump around
- ACTUAL: the video seeking get chaotic and the timeline jumps back and forth before all the seeks are resolved

